### PR TITLE
Avoid autowiring for KeycloakResourceOwner class.

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -6,7 +6,7 @@ services:
 
     IDCI\Bundle\KeycloakSecurityBundle\:
         resource: '../../*'
-        exclude: '../../{Entity,Migrations,Tests}'
+        exclude: '../../{Entity,Migrations,Tests,Provider/KeycloakResourceOwner.php}'
 
     IDCI\Bundle\KeycloakSecurityBundle\Security\Authenticator\KeycloakAuthenticator:
         arguments: ["@knpu.oauth2.registry", "@router"]


### PR DESCRIPTION
I've got the following error when using the bundle
```sh
Cannot autowire service "IDCI\Bundle\KeycloakSecurityBundle\Provider\KeycloakResourceOwner": argument "$token" of method "__construct()" references class "League\OAuth2\Client\Token\AccessToken" but no such service exists.
```

I suppose that `KeycloakResourceOwner` does not have to be a service because it is created in [this factory method](https://github.com/IDCI-Consulting/IDCIKeycloakSecurityBundle/blob/7fa572a6688e69a836bf49c3b71bb52674606239/Provider/Keycloak.php#L152-L158).

Am I wrong ?