### PR TITLE
Fix: Symfony deprecation calls.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,10 +9,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('idci_keycloak_security');
+        $treeBuilder = new TreeBuilder('idci_keycloak_security');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
                 ->scalarNode('default_target_path')
                     ->isRequired()

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ security:
         # Bearer token authentication
         api:
             pattern: ^/api
-            provider: idci_keycloak_bearer_security_provider
-            simple_preauth:
-                authenticator: IDCI\Bundle\KeycloakSecurityBundle\Security\Authenticator\KeycloakBearerAuthenticator
+            guard:
+                provider: idci_keycloak_bearer_security_provider
+                authenticators:
+                    - IDCI\Bundle\KeycloakSecurityBundle\Security\Authenticator\KeycloakBearerAuthenticator
 
     role_hierarchy:
         ROLE_ADMIN: ROLE_USER

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -8,6 +8,10 @@ services:
         resource: '../../*'
         exclude: '../../{Entity,Migrations,Tests,Provider/KeycloakResourceOwner.php}'
 
+    IDCI\Bundle\KeycloakSecurityBundle\Controller\:
+        resource: '../../Controller'
+        tags: ['controller.service_arguments']
+
     IDCI\Bundle\KeycloakSecurityBundle\Security\Authenticator\KeycloakAuthenticator:
         arguments: ["@knpu.oauth2.registry", "@router"]
 


### PR DESCRIPTION
Concerned issue:  #4 

- The KeycloakBearerAuthenticator will extends
AbstractGuardAuthenticator instead of SimplePreAuthenticatorInterface & AuthenticationFailureHandlerInterface.
- Fix root node configuration.
- Use autowiring in KeycloakController.
- Update README.