### PR TITLE
Make KeycloakBearerAuthenticator::formatToken protected

### DIFF
--- a/Security/Authenticator/KeycloakBearerAuthenticator.php
+++ b/Security/Authenticator/KeycloakBearerAuthenticator.php
@@ -72,7 +72,7 @@ class KeycloakBearerAuthenticator extends AbstractGuardAuthenticator
         return false;
     }
 
-    private function formatToken(string $token): string
+    protected function formatToken(string $token): string
     {
         return trim(preg_replace('/^(?:\s+)?Bearer\s/', '', $token));
     }


### PR DESCRIPTION
Making it `protected` would have the advantage that it can be used in a custom KeycloakBearerAuthenticator that extends the current class.