### PR TITLE
Fix invalid scope when using keycloak version >= 10

### DIFF
--- a/Provider/Keycloak.php
+++ b/Provider/Keycloak.php
@@ -147,7 +147,12 @@ class Keycloak extends AbstractProvider
 
     protected function getDefaultScopes(): array
     {
-        return ['name', 'email'];
+        return ['profile', 'email'];
+    }
+    
+    protected function getScopeSeparator(): string
+    {
+        return ' ';
     }
 
     protected function checkResponse(ResponseInterface $response, $data)


### PR DESCRIPTION
Hello 👋

We got an invalid scope when using keycloak version +10

Take a look
https://github.com/stevenmaguire/oauth2-keycloak/issues/25

Thank you 😄 