### PR TITLE
Leaner release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 Resources/docs/ export-ignore
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Resources/docs/ export-ignore


### PR DESCRIPTION
Remove `Resouce/docs` from release, making the dependency loose all screenshot => -5.0MiB in composer dependencies 