### PR TITLE
Fix Error when getDisplayName-Method of KeycloakUser is null

### DIFF
--- a/Security/User/KeycloakUser.php
+++ b/Security/User/KeycloakUser.php
@@ -50,7 +50,24 @@ class KeycloakUser extends OAuthUser
 
     public function __toString(): string
     {
-        return $this->getDisplayName();
+        $displayName = $this->getDisplayName();
+        $email = $this->getEmail();
+        $resources = $this->getResources();
+        $preferredUsername = $resources['preferred_username'] ?? null;
+ 
+        if ($displayName) {
+            return $displayName;
+        }
+ 
+        if ($email) {
+            return $email;
+        }
+ 
+        if ($preferredUsername) {
+            return $preferredUsername;
+        }
+ 
+        return 'Unknown User';
     }
 
     public function getAccessToken(): ?AccessToken


### PR DESCRIPTION
Fix Exception: "IDCI\Bundle\KeycloakSecurityBundle\Security\User\KeycloakUser::__toString(): Return value must be of type string, null returned"

Exception occurs, when the getDisplayName() Method returns null.