### PR TITLE
Fix Error when token length is too long

### DIFF
--- a/Security/Authenticator/KeycloakAuthenticator.php
+++ b/Security/Authenticator/KeycloakAuthenticator.php
@@ -37,6 +37,8 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements InteractiveAu
     {
         $client = $this->getKeycloakClient();
         $accessToken = $this->fetchAccessToken($client);
+        $keycloakUser = $client->fetchUserFromToken($accessToken);
+        $username = $keycloakUser->getPreferredUsername();
         if (null === $accessToken) {
             // The token header was empty, authentication fails with HTTP Status
             // Code 401 "Unauthorized"
@@ -44,7 +46,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements InteractiveAu
         }
 
         return new SelfValidatingPassport(
-            new UserBadge($accessToken->getToken(), function() use ($accessToken) {
+            new UserBadge($username, function() use ($accessToken) {
                 return $this->userProvider->loadUserByIdentifier($accessToken);
             })
         );


### PR DESCRIPTION
We face this issue when token length greater that 4096 because $userIdentifier length in security class UserBadge cannot be greater than MAX_USERNAME_LENGTH set to 4096.

By using the getPreferredUsername method of Keycloak we should get smaller strings contained in the claim (email or username mostly) 